### PR TITLE
docs: update environment variable setup instructions

### DIFF
--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -62,15 +62,13 @@ The hooks will run automatically on commit and include:
 
 ## Environment Variables
 
-Copy the example environment file and update it with your values:
+If your development workflow requires environment variables, create a local
+`.envrc` file with the required values and load it using `direnv` or source it
+manually:
 
 ```bash
-cp .envrc.example .envrc
+source .envrc
 ```
-
-Then, either:
-- Use [direnv](https://direnv.net/) to automatically load the environment variables
-- Source the file manually: `source .envrc`
 
 ## Testing
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -63,11 +63,10 @@ The hooks will run automatically on commit and include:
 ## Environment Variables
 
 If your development workflow requires environment variables, create a local
-`.envrc` file with the required values and load it using `direnv` or source it
-manually:
+`.envrc` file with the required values and load it using `direnv`:
 
 ```bash
-source .envrc
+direnv allow
 ```
 
 ## Testing


### PR DESCRIPTION
## Summary

Updated `docs/DEV_SETUP.md` to better reflect the current repository state.

### Changes
- Removed the outdated `.envrc.example` setup instruction.
- Updated the environment variables section to explain how to use a local `.envrc` file if needed.
- No Terraform module behavior was changed.

Fixes #22