### PR TITLE
fix(ci): correct dependabot directories for terraform and remove invalid docker entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
-  # Terraform
+  # Terraform modules and examples
   - package-ecosystem: "terraform"
-    directory: "/"
+    directories:
+      - "/modules/*"
+      - "/modules/*/examples/*"
+      - "/examples/*"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 10
@@ -19,13 +22,3 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-
-  # Docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "docker"


### PR DESCRIPTION
## Summary

- **Terraform**: dependabot was pointed at `directory: "/"` but there are no `.tf` files in the repo root — all Terraform lives under `modules/` and `examples/`. This caused every scheduled run to fail with `No files found in /`. Fixed by switching to `directories` with globs: `/modules/*`, `/modules/*/examples/*`, and `/examples/*`.
- **Docker**: removed the `docker` ecosystem entry entirely — there are no Dockerfiles in this repository, so the job was failing with `No Dockerfiles nor Kubernetes YAML found in /` on every run.

## Root cause

The `dependabot.yml` was using generic top-level config (`directory: "/"`) that doesn't match the actual repo layout, producing two failing CI jobs on every Dependabot scheduled run.

## Test plan

- [ ] Verify the Dependabot scheduled run no longer fails for `terraform` or `docker` after this merges
- [ ] Confirm `github-actions` updates continue to work (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency monitoring to cover Terraform modules and examples.
  * Removed automated Docker dependency update monitoring.
  * Continued monitoring GitHub Actions dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->